### PR TITLE
deps: bump versions to match upstream base image

### DIFF
--- a/photons-interactor/Dockerfile
+++ b/photons-interactor/Dockerfile
@@ -32,9 +32,9 @@ RUN \
     apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-    bash=5.2.15-2+b2 \
+    bash=5.2.15-2+b7 \
     ca-certificates=20230311 \
-    curl=7.88.1-10+deb12u6 \
+    curl=7.88.1-10+deb12u7 \
     jq=1.6-2.1 \
     tzdata=2024a-0+deb12u1 \
     xz-utils=5.4.1-0.2 \


### PR DESCRIPTION
Needed for the container to build successfully.