### PR TITLE
fix: use correct package versions

### DIFF
--- a/photons-interactor/Dockerfile
+++ b/photons-interactor/Dockerfile
@@ -34,9 +34,9 @@ RUN \
     && apt-get install -y --no-install-recommends \
     bash=5.2.15-2+b7 \
     ca-certificates=20230311 \
-    curl=7.88.1-10+deb12u7 \
+    curl=7.88.1-10+deb12u8 \
     jq=1.6-2.1 \
-    tzdata=2024a-0+deb12u1 \
+    tzdata=2024b-0+deb12u1 \
     xz-utils=5.4.1-0.2 \
     \
     && c_rehash \


### PR DESCRIPTION
The `Dockerfile` had older package versions so `apt-get` complains about downgrading and then goes to sulk in the corner. This fixes the problem.